### PR TITLE
Replace GafferOnGames with Archived Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Please feel free to contribute after reading [contribution guidelines](CONTRIBUT
 
 - [Ethernet vs. WiFi](https://na.leagueoflegends.com/en/page/ethernet-vs-wifi-ping-packets-playing-better) - Internet connection over WiFi vs Ethernet metrics comparison by Viscarious from Riot Games.
 - [Fast-Paced Multiplayer](http://www.gabrielgambetta.com/client-server-game-architecture.html) - Gabriel Gambetta's client-side prediction, entity interpolation, lag compensation articles.
-- [Gaffer on Games](https://gafferongames.com/) - Glenn Fiedler's reliable-UDP protocol and game network development articles.
+- [Gaffer on Games](https://web.archive.org/web/20190328001900/https://gafferongames.com/) - Glenn Fiedler's reliable-UDP protocol and game network development articles.
 - [Game Server Architecture](https://gameserverarchitecture.com/) - Matthew Walker's multiplayer game server architecture blog.
 - [High Performance Browser Networking](https://hpbn.co/) - A fantastic free online book about modern web protocols by Ilya Grigorik.
 - [How a Shooter Shoots](https://kotaku.com/5869564/networking-how-a-shooter-shoots) - Armin Ronacher's analysis on Battlefield 3's shooting mechanism in multiplayer.


### PR DESCRIPTION
GafferOnGames.com has been down for just under a month now and he has said multiple times on twitter he intends on fixing it, but nothing has been done so far. Temporary backup.